### PR TITLE
Show profile pages

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,8 @@ import Login from "./pages/auth/login";
 import Register from "./pages/auth/register";
 import NotFound from "./pages/404";
 import Home from "./pages/home";
+import Profiles from "./pages/profile/index";
+import Profile from "./pages/profile/profile";
 
 function App() {
   return (
@@ -11,6 +13,9 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
+        <Route path="/profiles" element={<Profiles />} />
+        <Route exact path="/profile/:userId" element={<Profile />} />
+        <Route path="/404" element={<NotFound />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </div>

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -4,6 +4,12 @@ import {
   SIGN_IN,
   SIGN_IN_ERROR,
   SIGN_OUT,
+  GET_USERS,
+  GET_USER,
+  GET_FOLLOWERS,
+  GET_FOLLOWING,
+  FOLLOW_USER,
+  UNFOLLOW_USER,
 } from "./types";
 import axios from "lib/axios";
 
@@ -44,4 +50,52 @@ export const signOut = () => async (dispatch) => {
   await axios.post("logout");
 
   dispatch({ type: SIGN_OUT });
+};
+
+export const fetchUsers = () => async (dispatch) => {
+  await csrf();
+
+  const response = await axios.get("api/users");
+
+  dispatch({ type: GET_USERS, payload: response.data });
+};
+
+export const fetchUser = (id) => async (dispatch) => {
+  await csrf();
+
+  const response = await axios.get("api/users/" + id);
+
+  dispatch({ type: GET_USER, payload: response.data });
+};
+
+export const fetchFollowers = (id) => async (dispatch) => {
+  await csrf();
+
+  const response = await axios.get("api/followers/" + id);
+
+  dispatch({ type: GET_FOLLOWERS, payload: response.data });
+};
+
+export const fetchFollowing = (id) => async (dispatch) => {
+  await csrf();
+
+  const response = await axios.get("api/following/" + id);
+
+  dispatch({ type: GET_FOLLOWING, payload: response.data });
+};
+
+export const followUser = (id) => async (dispatch) => {
+  await csrf();
+
+  const response = await axios.post("api/followers/" + id);
+
+  dispatch({ type: FOLLOW_USER, payload: response.data });
+};
+
+export const unfollowUser = (id) => async (dispatch) => {
+  await csrf();
+
+  const response = await axios.delete("api/followers/" + id);
+
+  dispatch({ type: UNFOLLOW_USER, payload: response.data });
 };

--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -3,3 +3,10 @@ export const SIGN_IN_ERROR = "SIGN_IN_ERROR";
 export const SIGN_OUT = "SIGN_OUT";
 export const REGISTER = "REGISTER";
 export const REGISTER_ERROR = "REGISTER_ERROR";
+
+export const GET_USERS = "GET_USERS";
+export const GET_USER = "GET_USER";
+export const GET_FOLLOWERS = "GET_FOLLOWERS";
+export const GET_FOLLOWING = "GET_FOLLOWING";
+export const FOLLOW_USER = "FOLLOW_USER";
+export const UNFOLLOW_USER = "UNFOLLOW_USER";

--- a/client/src/components/layouts/Loading.js
+++ b/client/src/components/layouts/Loading.js
@@ -1,0 +1,29 @@
+import AppLayout from "./AppLayout";
+
+const Loading = () => {
+  return (
+    <AppLayout>
+      <div className="flex items-center justify-center">
+        <div className="flex justify-center items-center space-x-1 text-sm text-gray-700">
+          <svg
+            fill="none"
+            className="w-12 h-12 animate-spin"
+            viewBox="0 0 32 32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M15.165 8.53a.5.5 0 01-.404.58A7 7 0 1023 16a.5.5 0 011 0 8 8 0 11-9.416-7.874.5.5 0 01.58.404z"
+              fill="currentColor"
+              fillRule="evenodd"
+            />
+          </svg>
+
+          <div className="text-xl font-bold">Loading...</div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default Loading;

--- a/client/src/components/layouts/Navigation.js
+++ b/client/src/components/layouts/Navigation.js
@@ -3,7 +3,7 @@ import { Fragment } from "react";
 import { Disclosure, Menu, Transition } from "@headlessui/react";
 import { MenuIcon, XIcon } from "@heroicons/react/outline";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 import { signOut } from "actions";
 
 function classNames(...classes) {
@@ -16,14 +16,12 @@ const Navigation = ({ users }) => {
 
   const auth = useSelector((state) => state.auth);
 
-  const user = {
-    name: "Tom Cook",
-    email: "tom@example.com",
-    imageUrl:
-      "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80",
-  };
+  const navigation = [
+    { name: "Dashboard", link: "/", current: true },
+    { name: "Profiles", link: "/profiles" },
+  ];
 
-  const navigation = [{ name: "Dashboard", href: "#", current: true }];
+  const [open, setOpen] = useState(false);
 
   const logout = () => {
     dispatch(signOut());
@@ -34,8 +32,6 @@ const Navigation = ({ users }) => {
       navigate("/login");
     }
   }, [auth]);
-
-  const [open, setOpen] = useState(false);
 
   return (
     <Disclosure as="nav" className="bg-white shadow-sm">
@@ -60,19 +56,13 @@ const Navigation = ({ users }) => {
 
                 <div className="hidden sm:-my-px sm:ml-6 sm:flex sm:space-x-8">
                   {navigation.map((item) => (
-                    <a
+                    <NavLink
                       key={item.name}
-                      href={item.href}
-                      className={classNames(
-                        item.current
-                          ? "border-indigo-500 text-gray-900"
-                          : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300",
-                        "inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
-                      )}
-                      aria-current={item.current ? "page" : undefined}
+                      to={item.link}
+                      className="border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium"
                     >
                       {item.name}
-                    </a>
+                    </NavLink>
                   ))}
                 </div>
               </div>
@@ -83,7 +73,7 @@ const Navigation = ({ users }) => {
                       <span className="sr-only">Open user menu</span>
                       <img
                         className="h-8 w-8 rounded-full"
-                        src={user.imageUrl}
+                        src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
                         alt=""
                       />
                     </Menu.Button>
@@ -98,6 +88,19 @@ const Navigation = ({ users }) => {
                     leaveTo="transform opacity-0 scale-95"
                   >
                     <Menu.Items className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+                      <Menu.Item>
+                        {({ active }) => (
+                          <Link
+                            to={`/profile/${auth.user.data?.id}`}
+                            className={classNames(
+                              active ? "bg-gray-100" : "",
+                              "block px-4 py-2 text-sm text-gray-700 cursor-pointer"
+                            )}
+                          >
+                            Profile
+                          </Link>
+                        )}
+                      </Menu.Item>
                       <Menu.Item>
                         {({ active }) => (
                           <a
@@ -153,16 +156,16 @@ const Navigation = ({ users }) => {
                 <div className="flex-shrink-0">
                   <img
                     className="h-10 w-10 rounded-full"
-                    src={user.imageUrl}
+                    src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
                     alt=""
                   />
                 </div>
                 <div className="ml-3">
                   <div className="text-base font-medium text-gray-800">
-                    {user.name}
+                    {auth.user?.data.name}
                   </div>
                   <div className="text-sm font-medium text-gray-500">
-                    {user.email}
+                    {auth.user?.data.email}
                   </div>
                 </div>
                 <button
@@ -172,6 +175,14 @@ const Navigation = ({ users }) => {
               </div>
               <div className="mt-3 space-y-1">
                 <Disclosure.Button
+                  as="a"
+                  href={`/profile/${auth.user?.data.id}`}
+                  className="block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100"
+                >
+                  Your Profile
+                </Disclosure.Button>
+                <Disclosure.Button
+                  as="button"
                   onClick={logout}
                   className="block px-4 py-2 text-base font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100"
                 >

--- a/client/src/pages/profile/index.js
+++ b/client/src/pages/profile/index.js
@@ -17,7 +17,7 @@ const Profiles = (props) => {
   if (!users.data || !users.data.length) {
     return <Loading />;
   }
-  console.log(auth.user.data.id);
+
   const filteredUsers = users.data.filter((user) => {
     return user.id !== auth.user.data.id;
   });

--- a/client/src/pages/profile/index.js
+++ b/client/src/pages/profile/index.js
@@ -1,0 +1,69 @@
+import { connect, useDispatch, useSelector } from "react-redux";
+import { useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { fetchUsers } from "actions";
+import AppLayout from "components/layouts/AppLayout";
+import Loading from "components/layouts/Loading";
+
+const Profiles = (props) => {
+  const navigate = useNavigate();
+  const auth = useSelector((state) => state.auth);
+  useEffect(() => {
+    props.fetchUsers();
+  }, []);
+
+  const { users } = props;
+
+  if (!users.data || !users.data.length) {
+    return <Loading />;
+  }
+  console.log(auth.user.data.id);
+  const filteredUsers = users.data.filter((user) => {
+    return user.id !== auth.user.data.id;
+  });
+
+  return (
+    <AppLayout
+      header={
+        <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+          Profiles
+        </h2>
+      }
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {filteredUsers.map((user) => (
+          <Link
+            to={`/profile/${user.id}`}
+            key={user.email}
+            className="relative rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500"
+          >
+            <div className="flex-shrink-0">
+              <img
+                className="h-10 w-10 rounded-full"
+                src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80"
+                alt=""
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="focus:outline-none">
+                <span className="absolute inset-0" aria-hidden="true" />
+                <p className="text-sm font-medium text-gray-900">{user.name}</p>
+                <p className="text-sm text-gray-500 truncate">{user.email}</p>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </AppLayout>
+  );
+};
+
+const mapStateToProps = (state) => {
+  return {
+    users: state.users,
+  };
+};
+
+export default connect(mapStateToProps, {
+  fetchUsers,
+})(Profiles);

--- a/client/src/pages/profile/index.js
+++ b/client/src/pages/profile/index.js
@@ -1,18 +1,19 @@
-import { connect, useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { fetchUsers } from "actions";
 import AppLayout from "components/layouts/AppLayout";
 import Loading from "components/layouts/Loading";
+import { fetchUsers } from "actions";
 
 const Profiles = (props) => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const auth = useSelector((state) => state.auth);
-  useEffect(() => {
-    props.fetchUsers();
-  }, []);
+  const users = useSelector((state) => state.users);
 
-  const { users } = props;
+  useEffect(() => {
+    dispatch(fetchUsers());
+  }, []);
 
   if (!users.data || !users.data.length) {
     return <Loading />;
@@ -58,12 +59,4 @@ const Profiles = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    users: state.users,
-  };
-};
-
-export default connect(mapStateToProps, {
-  fetchUsers,
-})(Profiles);
+export default Profiles;

--- a/client/src/pages/profile/profile.js
+++ b/client/src/pages/profile/profile.js
@@ -1,0 +1,139 @@
+import { connect, useDispatch } from "react-redux";
+import { useParams } from "react-router";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  fetchUser,
+  fetchFollowers,
+  fetchFollowing,
+  followUser,
+  unfollowUser,
+} from "actions";
+import AppLayout from "components/layouts/AppLayout";
+import Loading from "components/layouts/Loading";
+
+const Profile = (props) => {
+  let { userId } = useParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const follow = (id) => {
+    dispatch(followUser(id));
+
+    navigate("/");
+  };
+
+  const unfollow = (id) => {
+    dispatch(unfollowUser(id));
+
+    navigate("/");
+  };
+
+  useEffect(() => {
+    props.fetchUser(userId);
+    props.fetchFollowers(userId);
+    props.fetchFollowing(userId);
+  }, []);
+
+  if (
+    !props.user.data ||
+    !props.followers.data ||
+    !props.following.data ||
+    !props.auth
+  ) {
+    return <Loading />;
+  }
+
+  const { user } = props.auth;
+  const { is_admin, name, id } = props.user.data;
+  const { followers, following } = props;
+
+  if (is_admin === 1) {
+    navigate("/404");
+  }
+
+  const renderFollowButton = () => {
+    const isFound = followers.data.some((element) => {
+      if (element.id === user.data.id) {
+        return true;
+      }
+      return false;
+    });
+    if (isFound) {
+      return (
+        <button
+          onClick={() => unfollow(id)}
+          type="button"
+          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-red-500"
+        >
+          Unfollow
+        </button>
+      );
+    }
+
+    if (id !== user.data.id) {
+      return (
+        <button
+          onClick={() => follow(id)}
+          type="button"
+          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-blue-500"
+        >
+          Follow
+        </button>
+      );
+    }
+  };
+
+  return (
+    <AppLayout
+      header={
+        <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+          Profile
+        </h2>
+      }
+    >
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 md:flex md:items-center md:justify-between md:space-x-5 lg:max-w-7xl lg:px-8">
+        <div className="flex items-center space-x-5">
+          <div className="flex-shrink-0">
+            <div className="relative">
+              <img
+                className="h-16 w-16 rounded-full"
+                src="https://images.unsplash.com/photo-1463453091185-61582044d556?ixlib=rb-=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=8&w=1024&h=1024&q=80"
+                alt=""
+              />
+              <span
+                className="absolute inset-0 shadow-inner rounded-full"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">{name}</h1>
+            <div className="text-sm font-medium text-gray-500">
+              <div className="mr-4">Following: {following.data.length}</div>
+              <div className="mr-4">Followers: {followers.data.length}</div>
+            </div>
+          </div>
+        </div>
+        <div className="mt-6 flex flex-col-reverse justify-stretch space-y-4 space-y-reverse sm:flex-row-reverse sm:justify-end sm:space-x-reverse sm:space-y-0 sm:space-x-3 md:mt-0 md:flex-row md:space-x-3">
+          {renderFollowButton()}
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+const mapStateToProps = (state) => {
+  return {
+    auth: state.auth,
+    user: state.users,
+    followers: state.followers,
+    following: state.following,
+  };
+};
+
+export default connect(mapStateToProps, {
+  fetchUser,
+  fetchFollowers,
+  fetchFollowing,
+})(Profile);

--- a/client/src/pages/profile/profile.js
+++ b/client/src/pages/profile/profile.js
@@ -1,4 +1,4 @@
-import { connect, useDispatch } from "react-redux";
+import { connect, useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
@@ -12,10 +12,15 @@ import {
 import AppLayout from "components/layouts/AppLayout";
 import Loading from "components/layouts/Loading";
 
-const Profile = (props) => {
+const Profile = () => {
   let { userId } = useParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
+
+  const user = useSelector((state) => state.users);
+  const followers = useSelector((state) => state.followers);
+  const following = useSelector((state) => state.following);
+  const auth = useSelector((state) => state.auth);
 
   const follow = (id) => {
     dispatch(followUser(id));
@@ -30,39 +35,31 @@ const Profile = (props) => {
   };
 
   useEffect(() => {
-    props.fetchUser(userId);
-    props.fetchFollowers(userId);
-    props.fetchFollowing(userId);
+    dispatch(fetchUser(userId));
+    dispatch(fetchFollowers(userId));
+    dispatch(fetchFollowing(userId));
   }, []);
 
-  if (
-    !props.user.data ||
-    !props.followers.data ||
-    !props.following.data ||
-    !props.auth
-  ) {
+  if (!user.data || !followers.data || !following.data || !auth) {
     return <Loading />;
   }
 
-  const { user } = props.auth;
-  const { is_admin, name, id } = props.user.data;
-  const { followers, following } = props;
-
-  if (is_admin === 1) {
+  if (user.is_admin === 1) {
     navigate("/404");
   }
 
   const renderFollowButton = () => {
     const isFound = followers.data.some((element) => {
-      if (element.id === user.data.id) {
+      if (element.id === auth.user.data.id) {
         return true;
       }
       return false;
     });
+
     if (isFound) {
       return (
         <button
-          onClick={() => unfollow(id)}
+          onClick={() => unfollow(user.data.id)}
           type="button"
           className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-red-500"
         >
@@ -71,10 +68,10 @@ const Profile = (props) => {
       );
     }
 
-    if (id !== user.data.id) {
+    if (auth.user.data.id !== user.data.id) {
       return (
         <button
-          onClick={() => follow(id)}
+          onClick={() => follow(user.data.id)}
           type="button"
           className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-blue-500"
         >
@@ -108,7 +105,9 @@ const Profile = (props) => {
             </div>
           </div>
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">{name}</h1>
+            <h1 className="text-2xl font-bold text-gray-900">
+              {user.data.name}
+            </h1>
             <div className="text-sm font-medium text-gray-500">
               <div className="mr-4">Following: {following.data.length}</div>
               <div className="mr-4">Followers: {followers.data.length}</div>
@@ -123,17 +122,4 @@ const Profile = (props) => {
   );
 };
 
-const mapStateToProps = (state) => {
-  return {
-    auth: state.auth,
-    user: state.users,
-    followers: state.followers,
-    following: state.following,
-  };
-};
-
-export default connect(mapStateToProps, {
-  fetchUser,
-  fetchFollowers,
-  fetchFollowing,
-})(Profile);
+export default Profile;

--- a/client/src/reducers/followersReducer.js
+++ b/client/src/reducers/followersReducer.js
@@ -1,0 +1,10 @@
+import { GET_FOLLOWERS } from "actions/types";
+
+export default (state = {}, action) => {
+  switch (action.type) {
+    case GET_FOLLOWERS:
+      return { ...state, data: action.payload.data };
+    default:
+      return state;
+  }
+};

--- a/client/src/reducers/followingReducer.js
+++ b/client/src/reducers/followingReducer.js
@@ -1,0 +1,14 @@
+import { FOLLOW_USER, GET_FOLLOWING, UNFOLLOW_USER } from "actions/types";
+
+export default (state = {}, action) => {
+  switch (action.type) {
+    case GET_FOLLOWING:
+      return { ...state, data: action.payload.data };
+    case FOLLOW_USER:
+      return { ...state, data: action.payload.data };
+    case UNFOLLOW_USER:
+      return { ...state, data: action.payload.data };
+    default:
+      return state;
+  }
+};

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,6 +1,12 @@
 import { combineReducers } from "redux";
 import authReducer from "./authReducer";
+import usersReducer from "./usersReducer";
+import followersReducer from "./followersReducer";
+import followingReducer from "./followingReducer";
 
 export default combineReducers({
   auth: authReducer,
+  users: usersReducer,
+  followers: followersReducer,
+  following: followingReducer,
 });

--- a/client/src/reducers/usersReducer.js
+++ b/client/src/reducers/usersReducer.js
@@ -1,0 +1,12 @@
+import { GET_USER, GET_USERS } from "../actions/types";
+
+export default (state = {}, action) => {
+  switch (action.type) {
+    case GET_USERS:
+      return { ...state, data: action.payload.data };
+    case GET_USER:
+      return { ...state, data: action.payload.data };
+    default:
+      return state;
+  }
+};

--- a/server/app/Http/Controllers/Api/CategoryController.php
+++ b/server/app/Http/Controllers/Api/CategoryController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CategoryResource;
+use App\Models\Category;
+use App\Http\Requests\StoreCategoryRequest;
+use App\Http\Requests\UpdateCategoryRequest;
+
+class CategoryController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection
+     */
+    public function index()
+    {
+        return CategoryResource::collection(Category::all());
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \App\Http\Requests\StoreCategoryRequest  $request
+     * @return CategoryResource|\Illuminate\Http\JsonResponse
+     */
+    public function store(StoreCategoryRequest $request)
+    {
+        $category = Category::create($request->validated());
+
+        return new CategoryResource($category);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\Category  $category
+     * @return CategoryResource
+     */
+    public function show(Category $category)
+    {
+        return new CategoryResource($category);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \App\Http\Requests\UpdateCategoryRequest  $request
+     * @param  \App\Models\Category  $category
+     * @return CategoryResource|\Illuminate\Http\JsonResponse
+     */
+    public function update(UpdateCategoryRequest $request, Category $category)
+    {
+        return new CategoryResource($category);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\Category  $category
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy(Category $category)
+    {
+        if (auth()->user()->is_admin) {
+            $category->delete();
+
+            return response()->json(['message' => 'Category deleted successfully.']);
+        } else {
+            return response()->json(['message' => 'You are not authorized to delete this resource.']);
+        }
+    }
+}

--- a/server/app/Http/Controllers/Api/UserController.php
+++ b/server/app/Http/Controllers/Api/UserController.php
@@ -19,11 +19,7 @@ class UserController extends Controller
      */
     public function index()
     {
-        if (auth()->user()->is_admin) {
-            return UserResource::collection(User::all());
-        } else {
-            return UserResource::collection(User::where('id', auth()->id())->get());
-        }
+        return UserResource::collection(User::whereIsAdmin(false)->get());
     }
 
     /**

--- a/server/database/factories/CategoryFactory.php
+++ b/server/database/factories/CategoryFactory.php
@@ -17,7 +17,7 @@ class CategoryFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->word,
+            'name' => $this->faker->unique()->word,
             'description' => $this->faker->sentence,
         ];
     }

--- a/server/database/factories/UserFactory.php
+++ b/server/database/factories/UserFactory.php
@@ -22,6 +22,7 @@ class UserFactory extends Factory
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'is_admin' => false,
             'remember_token' => Str::random(10),
         ];
     }

--- a/server/database/seeders/DatabaseSeeder.php
+++ b/server/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             AdminSeeder::class,
+            UserSeeder::class,
             CategorySeeder::class,
         ]);
     }

--- a/server/database/seeders/UserSeeder.php
+++ b/server/database/seeders/UserSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        User::factory()
+            ->count(10)
+            ->create();
+    }
+}

--- a/server/database/seeders/UserSeeder.php
+++ b/server/database/seeders/UserSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class UserSeeder extends Seeder
 {
@@ -15,6 +16,14 @@ class UserSeeder extends Seeder
      */
     public function run()
     {
+        //create user john doe
+        User::factory()->create([
+            'name' => 'John Doe',
+            'email' => 'john@gmail.com',
+            'password' => Hash::make('password'),
+            'is_admin' => false,
+        ]);
+
         User::factory()
             ->count(10)
             ->create();


### PR DESCRIPTION
## Asana Link
https://app.asana.com/0/1202373230087288/1202373365645286/f

## Commands
### Server
`cd  server`
`php artisan migrate:fresh --seed` //we need this because I have created a new seeder
`php artisan serve --host localhost`

### Client
`cd client`
`npm start`

## Pre-conditions
1. Login using a sample user (John Doe) with email of `john@gmail.com` and password of `password`.
2. Go to http://localhost:3000/profiles to show all user profiles
3. Go to http://localhost:3000/profiles/{user} to show a single user profile (Change {user} to an existing user id like 1, 2, 3, etc.)

## Expected Output
- A page for all profiles and a user profile will be displayed.

## Notes
- This feature can already follow/unfollow users
- The profile avatar is yet to be implemented that's why it's showing static images.
- Activity logs and words learned will be added later because it's from a different task
	
## Screenshots
#### All user profiles
![image](https://user-images.githubusercontent.com/105617272/173481117-08632ac7-ce07-478c-ab55-642ed45b1922.png)

#### A user profile
![image](https://user-images.githubusercontent.com/105617272/173481171-3e363da4-aff0-4ea8-8c4f-a840c6d0193b.png)

