### PR TITLE
[SELS-BUGFIX] Fix follow/unfollow in profile page

### DIFF
--- a/client/src/pages/profile/profile.js
+++ b/client/src/pages/profile/profile.js
@@ -24,21 +24,17 @@ const Profile = () => {
 
   const follow = (id) => {
     dispatch(followUser(id));
-
-    navigate("/");
   };
 
   const unfollow = (id) => {
     dispatch(unfollowUser(id));
-
-    navigate("/");
   };
 
   useEffect(() => {
     dispatch(fetchUser(userId));
     dispatch(fetchFollowers(userId));
     dispatch(fetchFollowing(userId));
-  }, []);
+  }, [dispatch]);
 
   if (!user.data || !followers.data || !following.data || !auth) {
     return <Loading />;

--- a/client/src/reducers/followersReducer.js
+++ b/client/src/reducers/followersReducer.js
@@ -1,9 +1,19 @@
-import { GET_FOLLOWERS } from "actions/types";
+import { FOLLOW_USER, GET_FOLLOWERS, UNFOLLOW_USER } from "actions/types";
 
-export default (state = {}, action) => {
+const INITIAL_STATE = {
+  data: [],
+};
+export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case GET_FOLLOWERS:
       return { ...state, data: action.payload.data };
+    case FOLLOW_USER:
+      return { ...state, data: action.payload.data };
+    case UNFOLLOW_USER:
+      return {
+        ...state,
+        data: state.data.filter((item) => item.id !== action.payload.data.id),
+      };
     default:
       return state;
   }

--- a/client/src/reducers/followingReducer.js
+++ b/client/src/reducers/followingReducer.js
@@ -1,12 +1,12 @@
-import { FOLLOW_USER, GET_FOLLOWING, UNFOLLOW_USER } from "actions/types";
+import { GET_FOLLOWING } from "actions/types";
 
-export default (state = {}, action) => {
+const INITIAL_STATE = {
+  data: [],
+};
+
+export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case GET_FOLLOWING:
-      return { ...state, data: action.payload.data };
-    case FOLLOW_USER:
-      return { ...state, data: action.payload.data };
-    case UNFOLLOW_USER:
       return { ...state, data: action.payload.data };
     default:
       return state;

--- a/server/app/Http/Controllers/Api/FollowerController.php
+++ b/server/app/Http/Controllers/Api/FollowerController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\FollowerResource;
+use App\Http\Resources\UserResource;
 use App\Models\User;
 use Illuminate\Http\Request;
 
@@ -63,6 +64,9 @@ class FollowerController extends Controller
     {
         $user->followers()->detach(auth()->id());
 
-        return response()->json(['message' => 'You are no longer following this user.']);
+        return response()->json([
+            'data' => new UserResource(auth()->user()),
+            'message' => 'You are no longer following this user.']
+        );
     }
 }


### PR DESCRIPTION
## Asana Link
https://app.asana.com/0/1202373230087288/1202470577718827/f

## Commands
### Server
`cd server`
`php artisan serve --host localhost`

## Pre-conditions
Login using user `john@gmail.com` `password`
Go to profile page and select a profile and follow/unfollower user.

## Expected Output
It will no longer redirect to home page when following/unfollowing a user and will display the number of followers automatically. The button will also changed according to state.

## Notes
This PR changed the response of deleting a follower resource in the API.
This PR has fixed the reducer of followers.